### PR TITLE
fix: update Python guide following black's stable release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: 'https://github.com/igorshubovych/markdownlint-cli'
-    rev: v0.28.1
+    rev: v0.31.1
     hooks:
       - id: markdownlint

--- a/guides/standards/python-standards.md
+++ b/guides/standards/python-standards.md
@@ -1,10 +1,10 @@
 # Python at The Data Shed
 
 Python is becoming more ubiquitous across The Data Shed engineering space, often
- the first choice of language for a new project.
+the first choice of language for a new project.
 
 The purpose of this page is to outline some best practices for Python development
- across t'Shed in order to facilitate standardisation and whatnot.
+across t'Shed in order to facilitate standardisation and whatnot.
 
 We should push these standards where we own the project.
 
@@ -15,15 +15,15 @@ For non-Shed-owned projects we should aim to follow existing standards set out ð
 ### Python 3
 
 The default version you should use is the latest currently supported across all
- 3 major cloud providers
- ([Azure](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python?tabs=asgi%2Cazurecli-linux%2Capplication-level#python-version),
- [AWS](https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html),
- [GCP](https://cloud.google.com/functions/docs/concepts/python-runtime).)
- At the time of writing, this is **3.9**.
+3 major cloud providers
+([Azure](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-python?tabs=asgi%2Cazurecli-linux%2Capplication-level#python-version),
+[AWS](https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html),
+[GCP](https://cloud.google.com/functions/docs/concepts/python-runtime).)
+At the time of writing, this is **3.9**.
 
 If your project does not currently use this version then you need to schedule a
- work item to upgrade. The version should be maintained as per the above and this
- should be accommodated in every project roadmap.
+work item to upgrade. The version should be maintained as per the above and this
+should be accommodated in every project roadmap.
 
 #### Python 2
 
@@ -32,22 +32,22 @@ If your project does not currently use this version then you need to schedule a
 ## Install
 
 While Python is pre-installed or easily available in many operating systems, we
- recommend: [`pyenv`](https://github.com/pyenv/pyenv).
+recommend: [`pyenv`](https://github.com/pyenv/pyenv).
 
 **Note**: it should be installed using the [`pyenv-installer`](https://github.com/pyenv/pyenv-installer)
- tool.
+tool.
 
 See the `pyenv` [documentation](https://github.com/pyenv/pyenv#choosing-the-python-version)
- on managing multiple Python versions for different projects.
+on managing multiple Python versions for different projects.
 
 ### Virtual Environments
 
 For managing virtual environments using `pyenv`, use the [`pyenv-virtualenv`](https://github.com/pyenv/pyenv-virtualenv)
- plugin. **Note**: this is installed by default when using the above `pyenv-installer`
- tool.
+plugin. **Note**: this is installed by default when using the above `pyenv-installer`
+tool.
 
 See the `pyenv-virtualenv` [documentation](https://github.com/pyenv/pyenv-virtualenv#activate-virtualenv)
- on managing multiple virtual environments for different projects.
+on managing multiple virtual environments for different projects.
 
 ## Formatting
 
@@ -56,13 +56,15 @@ We should aim for consistency and predictability across our Python code.
 ### Code Style
 
 Python code should be formatted using [`black`](https://pypi.org/project/black/),
- specifically the latest tagged release (even if this is tagged as a beta.)
+using the latest
+[stable](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy)
+version.
 
 #### Existing Projects
 
 When introducing `black` to a new project (or upgrading to a more recent version),
- make any formatting changes in an isolated merge-/pull-request. Don't confuse
- formatting with changes in logic.
+make any formatting changes in an isolated merge-/pull-request. Don't confuse
+formatting with changes in logic.
 
 ### Imports
 
@@ -72,10 +74,10 @@ Imports should be ordered as per [`isort`](https://pypi.org/project/isort/) (see
 ### Docstrings
 
 [Sphinx](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html)
- style docstrings should be used throughout.
+style docstrings should be used throughout.
 
- [`darglint`](https://github.com/terrencepreilly/darglint) is a useful tool for
- verifying that docstrings match the expected style.
+[`darglint`](https://github.com/terrencepreilly/darglint) is a useful tool for
+verifying that docstrings match the expected style.
 
 ## Dependency Checking
 
@@ -115,40 +117,40 @@ All new tests, however, should use `pytest`.
 ## `gitignore`
 
 [`.gitignore`](https://www.toptal.com/developers/gitignore/api/windows,linux,macos,vim,emacs,sublimetext,intellij,pycharm,visualstudiocode,python)
- file as provided by [gitignore.io](https://gitignore.io/).
+file as provided by [gitignore.io](https://gitignore.io/).
 
 The above should be used and any updates reflected in the template for all to use.
 
 Although [GitHub](https://github.com/github/gitignore) provides similar templates,
- they are more specific, missing many of the ancillary files added by OSs, IDEs,
-  etc.
+they are more specific, missing many of the ancillary files added by OSs, IDEs,
+etc.
 
 ## Requirements
 
 [`pip`](https://github.com/pypa/pip), making sure to update regularly to the latest
- version.
+version.
 
 Specifically, use the `python3 -m pip` variant for calling the `pip` module directly.
 
 ## Other Asides
 
 Some of the following fall outside the scope of this document but are included
- until such time as similar documents exist to replace these next headings.
+until such time as similar documents exist to replace these next headings.
 
 Others, such as the use of type hints in Python code, are currently only
- recommendations, though this may change as tooling gains more adoption.
+recommendations, though this may change as tooling gains more adoption.
 
 ### README
 
 All projects must include a README which is formatted as per the [CommonMark](https://commonmark.org/)
- specification and validated using [`markdownlint`](https://github.com/DavidAnson/markdownlint)
-  (or [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli)).
+specification and validated using [`markdownlint`](https://github.com/DavidAnson/markdownlint)
+(or [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli)).
 
 ### `pre-commit`
 
 [`pre-commit`](https://pre-commit.com/) is a framework for managing pre-commit
- hooks in variety of languages, including pre-configured hooks for many of the
- above tools. Its use is *highly* encouraged.
+hooks in variety of languages, including pre-configured hooks for many of the
+above tools. Its use is *highly* encouraged.
 
 ### Type Hints
 


### PR DESCRIPTION
- update guide to reflect Black's stable status;
- update the Markdownlint pre-commit hook to the latest version.