### PR TITLE
feat: add Terraform standards guide

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: 'https://github.com/igorshubovych/markdownlint-cli'
-    rev: v0.28.1
+    rev: v0.31.1
     hooks:
       - id: markdownlint

--- a/guides/standards/README.md
+++ b/guides/standards/README.md
@@ -3,5 +3,39 @@
 This is the single source of truth for coding and naming standards at The Data
 Shed.
 
-[Python](/guides/Standards/python_standards.md) #TODO  
-[SQL](/guides/Standards/sql_standards.md) #TODO
+- [Python](/guides/standards/python-standards.md)
+- [SQL](/guides/standards/sql-standards.md) #TODO
+- [Terraform](/guides/standards/terraform-standards.md)
+
+## General
+
+While the above describe standards and tooling appropriate to each language or
+framework, there are some which apply to all projects.
+
+## `pre-commit`
+
+Git [hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are a
+means by which automated action can be taken for certain events in the Git
+lifecycle.
+
+[`pre-commit`](https://pre-commit.com/) is a framework for managing a variety
+of tools, specifically for the
+[`pre-commit`](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks#_committing_workflow_hooks)
+hook.
+
+- all projects SHOULD make use of `pre-commit`;
+- any project using `pre-commit` MUST make use of its
+  [`autoupdate`](https://pre-commit.com/#updating-hooks-automatically) feature;
+- any project using `pre-commit` MUST
+  [run all hooks](https://pre-commit.com/#usage) as part of the CI/CD pipeline.
+
+There are some tools which SHOULD be used on every project, where appropriate:
+
+- [`markdownlint-cli`](https://github.com/igorshubovych/markdownlint-cli): most
+  projects have a `README.md` and such documents should be validated by
+  [`markdownlint`](https://github.com/DavidAnson/markdownlint);
+- [`detect-secrets`](https://github.com/Yelp/detect-secrets): needless to say,
+  the accidental addition of sensitive data to a project should be avoided;
+- [`gitleaks`](https://github.com/zricethezav/gitleaks/): similar to
+  `detect-secrets`, this aims to prevent to accidental addition of sensitive
+  values.

--- a/guides/standards/terraform-standards.md
+++ b/guides/standards/terraform-standards.md
@@ -1,0 +1,63 @@
+# Terraform
+
+[Terraform](https://www.terraform.io/) is an infrastructure-as-code tool
+developed by [HashiCorp](https://www.hashicorp.com/).
+
+At The Data Shed, this has become the de facto standard tool for provisioning
+infrastructure on our projects. Thanks to its declarative language and
+extensibility through
+"[providers](https://www.terraform.io/language/providers)" for every possible
+service, it is both versatile and highly maintainable.
+
+## Versions
+
+Terraform reached a stable 1.0 version only
+[relatively recently](https://www.hashicorp.com/blog/announcing-hashicorp-terraform-1-0-general-availability).
+While Terraform does now offer a stability guarantee, all projects:
+
+- SHOULD aim to use the most recent version and provide an upgrade path to
+  maintain this;
+- MUST define an upgrade path if on an older version.
+
+## Code Style
+
+All Terraform code MUST be formatted as per the provided standard (this may
+change when upgrading versions and this MUST be considered when doing so):
+
+```sh
+terraform fmt
+```
+
+This MUST be enforced in any CI/CD pipelines.
+
+## Static Code Analysis
+
+There are several tools available for static code analysis, whether for linting
+or more thorough Static Application Security Testing.
+
+- [`terraform validate`](https://www.terraform.io/cli/commands/validate)
+- [`checkov`](https://github.com/bridgecrewio/checkov)
+- [`terrascan`](https://github.com/accurics/terrascan)
+- [`tflint`](https://github.com/terraform-linters/tflint)
+- [`tfsec`](https://github.com/aquasecurity/tfsec)
+
+In some cases these tools will suggest actions inappropriate for a particular
+project; each, however, can allow these rules to be ignored. Where this
+happens, there MUST be appropriate explanation.
+
+Any project using Terraform SHOULD integrate these into their development
+workflows. Where any issues are flagged, any project MUST provide a path for
+remedial action.
+
+## `pre-commit`
+
+As with all other languages and frameworks, projects SHOULD make use of the
+[`pre-commit`](https://pre-commit.com/) framework.
+
+With regard to Terraform, there are some specific hooks which can be used:
+
+- [`pre-commit-terraform`](https://github.com/antonbabenko/pre-commit-terraform):
+  this has hooks for several of the aforementioned tools (and many more.)
+- [`checkov`](https://github.com/bridgecrewio/checkov): although
+  `pre-commit-terraform` includes a hook for `checkov`, this manages
+  installation of the binary too, making it simpler to use.


### PR DESCRIPTION
- add standard for Terraform, including tooling and `pre-commit` recommendations;
- bump the version of `pre-commit` hooks for this project.

closes #49