### PR TITLE
fix: Pre-Commit Version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,6 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: /home/runner/.cache/
-          key: "pre-commit==2.15.0"
-      - run: python3 -m pip install pre-commit==2.15.0
+          key: "pre-commit==2.20.0"
+      - run: python3 -m pip install pre-commit==2.20.0
       - run: pre-commit run --all


### PR DESCRIPTION
We introduced `default_install_hook_types` to our pre-commit configuration in
 this repo.

However this feature wasn't introduced to the `pre-commit` library until
 [v2.18.0](https://github.com/pre-commit/pre-commit/blob/78a2d867feac2c1602a608c1fa4eeecb2f8bb415/CHANGELOG.md#2180---2022-04-02)!

This yields a warning message in the CI pipeline:

> Warning:  Unexpected key(s) present at root: default_install_hook_types

Bumping the version to the current latest version (v2.20.0) resolves this.