### PR TITLE
docs: `pre-commit` Minimum Version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_install_hook_types: ["pre-commit", "commit-msg"]
 default_stages: [commit]
+minimum_pre_commit_version: 2.18.0
 
 repos:
   - repo: "https://github.com/igorshubovych/markdownlint-cli"

--- a/standards/README.md
+++ b/standards/README.md
@@ -49,4 +49,5 @@ following top-level options to your `.pre-commit-config.yaml` file:
 ```yaml
 default_install_hook_types: ["pre-commit", "commit-msg"]
 default_stages: [commit]
+minimum_pre_commit_version: 2.18.0
 ```


### PR DESCRIPTION
The `pre-commit` configuration option of `default_install_hook_types` was only
 introduced to `pre-commit` in v2.18.0.

Therefore it seems sensible to extend our default config to ensure folks aren't
 using a version older than this!